### PR TITLE
Add ini::Exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Using `std::basic_istream<char>` and `std::basic_ostream<char>` Gives more flexi
 
 ## Exceptions
 
-TODO: now the code just prints to stderr
+`ini::serialize` and `ini::deserialize` may throw `ini::Exception`, which is a subtype of [std::runtime_error](https://en.cppreference.com/w/cpp/error/runtime_error)
 
 ## Building from source
 

--- a/include/ini/Exception.h
+++ b/include/ini/Exception.h
@@ -1,0 +1,10 @@
+#include <string>
+
+namespace ini {
+
+class Exception : public std::runtime_error {
+public:
+    Exception(const std::string& whatMsg) : std::runtime_error(whatMsg) {}
+};
+
+}  // namespace ini

--- a/src/deserialize.cpp
+++ b/src/deserialize.cpp
@@ -1,7 +1,8 @@
 #include "ini/deserialize.h"
 
 #include <algorithm>
-#include <iostream>
+
+#include "ini/Exception.h"
 
 inline void rtrim(std::string& s) {
     s.erase(std::find_if(s.rbegin(), s.rend(),
@@ -30,8 +31,9 @@ Config deserialize(std::basic_istream<char>& input) {
 
         if (buffer.size() < 3 || buffer[0] != '[' ||
             buffer[buffer.size() - 1] != ']') {
-            std::cerr << "Cannot read: Invalid section name" << std::endl;
-            return config;
+            throw new ini::Exception(
+                std::string("Couldn't deserialize: Invalid section header '") +
+                buffer + "'");
         }
 
         std::string sectionName = buffer.substr(1, buffer.size() - 2);
@@ -43,8 +45,9 @@ Config deserialize(std::basic_istream<char>& input) {
 
             if (equal == buffer.end() || equal == buffer.begin() ||
                 equal == buffer.end() - 1) {
-                std::cerr << "Cannot read: Invalid line" << std::endl;
-                return config;
+                throw new ini::Exception(
+                    std::string("Couldn't deserialize: Invalid line '") +
+                    buffer + "'");
             }
 
             auto key = std::string(buffer.begin(), equal);

--- a/src/serialize.cpp
+++ b/src/serialize.cpp
@@ -1,15 +1,14 @@
 #include "ini/serialize.h"
 
-#include <iostream>
+#include "ini/Exception.h"
 
 namespace ini {
 
 void serialize(std::basic_ostream<char>& output, const Config& config) {
     for (const auto& kv : config) {
         if (kv.first.empty()) {
-            std::cerr << "Cannot write: Section name should not be empty"
-                      << std::endl;
-            return;
+            throw new ini::Exception(
+                "Couldn't serialize: Section name should not be empty");
         }
         output << "[" << kv.first << "]\n";
 


### PR DESCRIPTION
Exception class which extends std::runtime_error and takes a string as a parameter.

Can be thrown in ini::serialize and ini::deserialize